### PR TITLE
Pass context to address release callback

### DIFF
--- a/api/ucg.h
+++ b/api/ucg.h
@@ -106,7 +106,7 @@ typedef struct ucg_params {
                         ucg_group_member_index_t index,
                         ucp_address_t **addr,
                         size_t *addr_len);
-        void (*release_f)(ucp_address_t *addr);
+        void (*release_f)(void *cb_group_context, ucp_address_t *addr);
     } address;
 
     /*

--- a/base/ucg_context.h
+++ b/base/ucg_context.h
@@ -48,7 +48,8 @@ typedef struct ucg_context {
                         ucg_group_member_index_t index,
                         ucp_address_t **addr,
                         size_t *addr_len);
-        void (*release_f)(ucp_address_t *addr);
+        void (*release_f)(void *cb_group_context,
+                          ucp_address_t *addr);
     } address;
 
     ucg_context_config_t  config;

--- a/base/ucg_plan.c
+++ b/base/ucg_plan.c
@@ -360,7 +360,7 @@ ucs_status_t ucg_plan_connect(ucg_group_h group,
                 .address = remote_addr
         };
         status = ucp_ep_create(group->worker, &ep_params, &ucp_ep);
-        ucg_global_params.address.release_f(remote_addr);
+        ucg_global_params.address.release_f(group->params.cb_context, remote_addr);
         if (status != UCS_OK) {
             return status;
         }


### PR DESCRIPTION
# What & Why

Currently, `ucg_params_t.address.release_f` only takes `ucp_address_t`, which makes it hard to release address resource. For example, `ucp_worker_release_address(...)` requires `ucp_worker_h` to be released.

# How

Pass group's context to `release_f`, like `lookup_f`.